### PR TITLE
Encrypted database backups

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,55 @@
+<?php
+
+$date = date('Y');
+$header = <<<EOF
+This file is part of richardhj/contao-backup-manager.
+
+Copyright (c) 2018-$date Richard Henkenjohann
+
+@package   richardhj/contao-backup-manager
+@author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+@copyright 2018-$date Richard Henkenjohann
+@license   https://github.com/richardhj/contao-backup-manager/blob/master/LICENSE LGPL-3.0
+EOF;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        '@PHPUnit60Migration:risky' => true,
+        'align_multiline_comment' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'binary_operator_spaces' => ['align_double_arrow' => true, 'align_equals' => true],
+        'combine_consecutive_issets' => true,
+        'combine_consecutive_unsets' => true,
+        'comment_to_phpdoc' => true,
+        'compact_nullable_typehint' => true,
+        'declare_strict_types' => true,
+        'header_comment' => ['header' => $header],
+        'heredoc_to_nowdoc' => true,
+        'linebreak_after_opening_tag' => true,
+        'native_function_invocation' => [
+            'include' => ['@compiler_optimized'],
+        ],
+        'no_null_property_initialization' => true,
+        'no_superfluous_elseif' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'php_unit_strict' => true,
+        'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_order' => true,
+        'phpdoc_types_order' => [
+            'null_adjustment' => 'always_last',
+            'sort_algorithm' => 'none',
+        ],
+        'strict_comparison' => true,
+        'strict_param' => true,
+    ])
+    ->setFinder(PhpCsFixer\Finder::create()->in([__DIR__.'/src']))
+    ->setRiskyAllowed(true)
+    ->setUsingCache(false)
+;

--- a/README.md
+++ b/README.md
@@ -16,17 +16,71 @@ $ composer require richardhj/contao-backup-manager
 
 ## Usage
 
-### Database backup
+### Commands 
+#### Database backup
 
 Run `php vendor/bin/contao-console backup-manager:backup contao local -c gzip --filename backup.sql` to create a backup
 
 The dump will saved within the `/backups` folder in the website root.
 
-### Database restore
+#### Database restore
 
 Run `php vendor/bin/contao-console backup-manager:restore contao local backup.sql.gz -c gzip` to restore from a backup.
 
 The database dump will be searched within the `/backups` folder in the website root.
+
+### External storage
+
+You can define external storage for the database dump to upload to. An external SFTP storage, AWS, or many more storages
+are available. Please consult the documentation of [backup-manager](https://github.com/backup-manager/symfony) or see 
+the example in the section below.
+
+### File encryption
+
+You can encrypt the database dump before it will be uploaded on external storage. The encrypted file will be decrypted on-the-fly on restore.
+
+Example configuration to write encrypted files on an external SFTP storage:
+
+```yaml
+# /config/config.yml
+
+contao_backup_manager:
+  storage:
+    hetzner_enc:
+      type: Encrypted
+      storage: hetzner
+      encryption_key: '%env(DB_ENCRYPTION_KEY)%'
+    hetzner:
+      type: Sftp
+      host: '%env(DB_STORAGE_HOST)%'
+      username: '%env(DB_STORAGE_USERNAME)%'
+      password: '%env(DB_STORAGE_PASSWORD)%'
+      port: 22
+      root: '/db'
+      timeout: 10
+```
+
+```dotenv
+# /.env.local
+
+DB_STORAGE_HOST=storage.beispiel.de
+DB_STORAGE_USERNAME=user
+DB_STORAGE_PASSWORD=pass
+DB_ENCRYPTION_KEY=aaabbbcccddd
+```
+
+```shell script
+php vendor/bin/contao-console backup-manager:backup contao hetzner_enc -c gzip
+```
+
+The filesystem utilizes [libsodium's Poly1305](https://libsodium.gitbook.io/doc/advanced/poly1305) algorithm to 
+encrypt the files on-the-fly.
+
+To check the implementation, please consult 
+https://github.com/alextartan/flysystem-libsodium-adapter/blob/master/src/ChunkEncryption/Libsodium.php
+
+Note: The encryption algorithm might change in the future (only in major version releases), so this feature is 
+not recommended for long data retention.
 
 [ico-version]: https://img.shields.io/packagist/v/richardhj/contao-backup-manager.svg?style=flat-square
 [ico-license]: https://img.shields.io/badge/license-LGPL-brightgreen.svg?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,11 @@
   },
   "require": {
     "php": "^7.4",
-    "backup-manager/symfony": "^2.2",
+
     "contao/core-bundle": "^4.9",
+    "backup-manager/symfony": "^2.2",
+    "alextartan/flysystem-libsodium-adapter": "^1.0",
+
     "symfony/config": "^4.4",
     "symfony/http-kernel": "^4.4"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "source": "https://github.com/richardhj/contao-backup-manager"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.4",
     "backup-manager/symfony": "^2.2",
     "contao/core-bundle": "^4.9",
     "symfony/config": "^4.4",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -1,13 +1,15 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of richardhj/contao-backup-manager.
  *
- * Copyright (c) 2018-2018 Richard Henkenjohann
+ * Copyright (c) 2018-2020 Richard Henkenjohann
  *
  * @package   richardhj/contao-backup-manager
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2018-2018 Richard Henkenjohann
+ * @copyright 2018-2020 Richard Henkenjohann
  * @license   https://github.com/richardhj/contao-backup-manager/blob/master/LICENSE LGPL-3.0
  */
 
@@ -23,18 +25,13 @@ use Contao\ManagerPlugin\Config\ConfigPluginInterface;
 use Contao\ManagerPlugin\Config\ContainerBuilder;
 use Contao\ManagerPlugin\Config\ExtensionPluginInterface;
 use Contao\ManagerPlugin\Dependency\DependentPluginInterface;
-use Ferienpass\CoreBundle\Security\Authentication\AuthenticationFailureHandler;
 use Richardhj\ContaoBackupManager\RichardhjContaoBackupManagerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
-
 class Plugin implements BundlePluginInterface, ConfigPluginInterface, DependentPluginInterface, ExtensionPluginInterface
 {
-
     /**
      * Gets a list of autoload configurations for this bundle.
-     *
-     * @param ParserInterface $parser
      *
      * @return ConfigInterface[]
      */
@@ -50,7 +47,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, DependentP
 
     public function registerContainerConfiguration(LoaderInterface $loader, array $managerConfig)
     {
-        $loader->load(__DIR__ . '/../Resources/config/backup_manager.yml');
+        $loader->load(__DIR__.'/../Resources/config/backup_manager.yml');
     }
 
     public function getPackageDependencies()
@@ -69,7 +66,7 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, DependentP
         $config = $container->getExtensionConfig('contao_backup_manager');
         $config = array_merge(...$config);
 
-        $config['storage'] = array_filter($config['storage'] ?? [], fn($input) => 'Encrypted' !== $input['type']);
+        $config['storage'] = array_filter($config['storage'] ?? [], fn ($input) => 'Encrypted' !== $input['type']);
         if (empty($config['storage'])) {
             return $extensionConfigs;
         }

--- a/src/DependencyInjection/CompilerPass/ProvideFilesystemsPass.php
+++ b/src/DependencyInjection/CompilerPass/ProvideFilesystemsPass.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Richardhj\ContaoBackupManager\DependencyInjection\CompilerPass;
+
+use Richardhj\ContaoBackupManager\Filesystem\EncryptedFilesystem;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ProvideFilesystemsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $config = $container->getExtensionConfig('contao_backup_manager');
+        $config = array_merge(...$config);
+
+        if (!isset($config['storage'])) {
+            return;
+        }
+
+        $configStorageDef =  $container->getDefinition('backup_manager.config_storage');
+        $configStorage = $configStorageDef->getArgument(0);
+
+        $filesystemDef = $container->getDefinition('backup_manager.filesystems');
+        foreach ($config['storage'] as $storageKey => $storageConfig) {
+            if ('Encrypted' === $storageConfig['type']) {
+                $filesystemDef->addMethodCall('add', [new Reference(EncryptedFilesystem::class)]);
+
+                $configStorage += [
+                    $storageKey => $storageConfig
+                ];
+            }
+        }
+
+        $configStorageDef->replaceArgument(0, $configStorage);
+    }
+}

--- a/src/DependencyInjection/CompilerPass/ProvideFilesystemsPass.php
+++ b/src/DependencyInjection/CompilerPass/ProvideFilesystemsPass.php
@@ -1,10 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of richardhj/contao-backup-manager.
+ *
+ * Copyright (c) 2018-2020 Richard Henkenjohann
+ *
+ * @package   richardhj/contao-backup-manager
+ * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright 2018-2020 Richard Henkenjohann
+ * @license   https://github.com/richardhj/contao-backup-manager/blob/master/LICENSE LGPL-3.0
+ */
+
 namespace Richardhj\ContaoBackupManager\DependencyInjection\CompilerPass;
 
 use Richardhj\ContaoBackupManager\Filesystem\EncryptedFilesystem;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 class ProvideFilesystemsPass implements CompilerPassInterface
@@ -18,8 +31,8 @@ class ProvideFilesystemsPass implements CompilerPassInterface
             return;
         }
 
-        $configStorageDef =  $container->getDefinition('backup_manager.config_storage');
-        $configStorage = $configStorageDef->getArgument(0);
+        $configStorageDef = $container->getDefinition('backup_manager.config_storage');
+        $configStorage    = $configStorageDef->getArgument(0);
 
         $filesystemDef = $container->getDefinition('backup_manager.filesystems');
         foreach ($config['storage'] as $storageKey => $storageConfig) {
@@ -27,7 +40,7 @@ class ProvideFilesystemsPass implements CompilerPassInterface
                 $filesystemDef->addMethodCall('add', [new Reference(EncryptedFilesystem::class)]);
 
                 $configStorage += [
-                    $storageKey => $storageConfig
+                    $storageKey => $storageConfig,
                 ];
             }
         }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,5 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of richardhj/contao-backup-manager.
+ *
+ * Copyright (c) 2018-2020 Richard Henkenjohann
+ *
+ * @package   richardhj/contao-backup-manager
+ * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright 2018-2020 Richard Henkenjohann
+ * @license   https://github.com/richardhj/contao-backup-manager/blob/master/LICENSE LGPL-3.0
+ */
+
 namespace Richardhj\ContaoBackupManager\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -9,12 +22,12 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 class Configuration implements ConfigurationInterface
 {
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('contao_backup_manager');
-        $rootNode = $treeBuilder->getRootNode();
+        $rootNode    = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()
@@ -26,8 +39,8 @@ class Configuration implements ConfigurationInterface
                                     throw new InvalidConfigurationException(sprintf('You must define a "type" for storage "%s"', $name));
                                 }
 
-                                if ('Encrypted' === $config['type']){
-                                $this->validateAuthenticationType(['storage','encryption_key'], $config, 'Encrypted');
+                                if ('Encrypted' === $config['type']) {
+                                    $this->validateAuthenticationType(['storage', 'encryption_key'], $config, 'Encrypted');
                                 }
                             }
 
@@ -45,6 +58,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Validate that the configuration fragment has the specified keys and none other.
+     *
+     * @param mixed $typeName
      */
     private function validateAuthenticationType(array $expected, array $actual, $typeName)
     {
@@ -55,11 +70,6 @@ class Configuration implements ConfigurationInterface
             return;
         }
 
-        throw new InvalidConfigurationException(sprintf(
-            'Storage type "%s" received invalid key "%s". Please choose one of "%s".',
-            $typeName,
-            implode(', ', $expected),
-            implode(', ', $actual)
-        ));
+        throw new InvalidConfigurationException(sprintf('Storage type "%s" received invalid key "%s". Please choose one of "%s".', $typeName, implode(', ', $expected), implode(', ', $actual)));
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Richardhj\ContaoBackupManager\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder('contao_backup_manager');
+        $rootNode = $treeBuilder->getRootNode();
+
+        $rootNode
+            ->children()
+                ->variableNode('storage')
+                    ->validate()
+                        ->always(function ($storageConfig) {
+                            foreach ($storageConfig as $name => $config) {
+                                if (!isset($config['type'])) {
+                                    throw new InvalidConfigurationException(sprintf('You must define a "type" for storage "%s"', $name));
+                                }
+
+                                if ('Encrypted' === $config['type']){
+                                $this->validateAuthenticationType(['storage','encryption_key'], $config, 'Encrypted');
+                                }
+                            }
+
+                            return $storageConfig;
+                        })
+                    ->end()
+
+                ->end() // End storage
+
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+
+    /**
+     * Validate that the configuration fragment has the specified keys and none other.
+     */
+    private function validateAuthenticationType(array $expected, array $actual, $typeName)
+    {
+        unset($actual['type']);
+        $actual = array_keys($actual);
+
+        if (empty(array_diff($actual, $expected))) {
+            return;
+        }
+
+        throw new InvalidConfigurationException(sprintf(
+            'Storage type "%s" received invalid key "%s". Please choose one of "%s".',
+            $typeName,
+            implode(', ', $expected),
+            implode(', ', $actual)
+        ));
+    }
+}

--- a/src/DependencyInjection/ContaoBackupManagerExtension.php
+++ b/src/DependencyInjection/ContaoBackupManagerExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Richardhj\ContaoBackupManager\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class ContaoBackupManagerExtension extends Extension
+{
+    public function getAlias()
+    {
+        return 'contao_backup_manager';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $this->processConfiguration($configuration, $configs);
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}

--- a/src/DependencyInjection/ContaoBackupManagerExtension.php
+++ b/src/DependencyInjection/ContaoBackupManagerExtension.php
@@ -1,5 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of richardhj/contao-backup-manager.
+ *
+ * Copyright (c) 2018-2020 Richard Henkenjohann
+ *
+ * @package   richardhj/contao-backup-manager
+ * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright 2018-2020 Richard Henkenjohann
+ * @license   https://github.com/richardhj/contao-backup-manager/blob/master/LICENSE LGPL-3.0
+ */
+
 namespace Richardhj\ContaoBackupManager\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -15,7 +28,7 @@ class ContaoBackupManagerExtension extends Extension
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/src/Filesystem/EncryptedFilesystem.php
+++ b/src/Filesystem/EncryptedFilesystem.php
@@ -1,5 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
+/*
+ * This file is part of richardhj/contao-backup-manager.
+ *
+ * Copyright (c) 2018-2020 Richard Henkenjohann
+ *
+ * @package   richardhj/contao-backup-manager
+ * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright 2018-2020 Richard Henkenjohann
+ * @license   https://github.com/richardhj/contao-backup-manager/blob/master/LICENSE LGPL-3.0
+ */
+
 namespace Richardhj\ContaoBackupManager\Filesystem;
 
 use AlexTartan\Flysystem\Adapter\ChunkEncryption\Libsodium;
@@ -10,7 +23,6 @@ use League\Flysystem\Filesystem as Flysystem;
 
 class EncryptedFilesystem implements Filesystem
 {
-
     private FilesystemProvider $filesystems;
 
     public function __construct(FilesystemProvider $filesystems)
@@ -29,10 +41,7 @@ class EncryptedFilesystem implements Filesystem
 
         $encryption = Libsodium::factory($config['encryption_key'], 4096);
 
-        $adapterDecorator = new EncryptionAdapterDecorator(
-            $adapter,
-            $encryption
-        );
+        $adapterDecorator = new EncryptionAdapterDecorator($adapter, $encryption);
 
         return new Flysystem($adapterDecorator);
     }

--- a/src/Filesystem/EncryptedFilesystem.php
+++ b/src/Filesystem/EncryptedFilesystem.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Richardhj\ContaoBackupManager\Filesystem;
+
+use AlexTartan\Flysystem\Adapter\ChunkEncryption\Libsodium;
+use AlexTartan\Flysystem\Adapter\EncryptionAdapterDecorator;
+use BackupManager\Filesystems\Filesystem;
+use BackupManager\Filesystems\FilesystemProvider;
+use League\Flysystem\Filesystem as Flysystem;
+
+class EncryptedFilesystem implements Filesystem
+{
+
+    private FilesystemProvider $filesystems;
+
+    public function __construct(FilesystemProvider $filesystems)
+    {
+        $this->filesystems = $filesystems;
+    }
+
+    public function handles($type)
+    {
+        return 'encrypted' === strtolower($type);
+    }
+
+    public function get(array $config)
+    {
+        $adapter = $this->filesystems->get($config['storage'])->getAdapter();
+
+        $encryption = Libsodium::factory($config['encryption_key'], 4096);
+
+        $adapterDecorator = new EncryptionAdapterDecorator(
+            $adapter,
+            $encryption
+        );
+
+        return new Flysystem($adapterDecorator);
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,0 +1,3 @@
+services:
+  Richardhj\ContaoBackupManager\Filesystem\EncryptedFilesystem:
+    arguments: ['@backup_manager.filesystems']

--- a/src/RichardhjContaoBackupManagerBundle.php
+++ b/src/RichardhjContaoBackupManagerBundle.php
@@ -1,13 +1,15 @@
 <?php
 
-/**
+declare(strict_types=1);
+
+/*
  * This file is part of richardhj/contao-backup-manager.
  *
- * Copyright (c) 2018-2018 Richard Henkenjohann
+ * Copyright (c) 2018-2020 Richard Henkenjohann
  *
  * @package   richardhj/contao-backup-manager
  * @author    Richard Henkenjohann <richardhenkenjohann@googlemail.com>
- * @copyright 2018-2018 Richard Henkenjohann
+ * @copyright 2018-2020 Richard Henkenjohann
  * @license   https://github.com/richardhj/contao-backup-manager/blob/master/LICENSE LGPL-3.0
  */
 

--- a/src/RichardhjContaoBackupManagerBundle.php
+++ b/src/RichardhjContaoBackupManagerBundle.php
@@ -13,9 +13,26 @@
 
 namespace Richardhj\ContaoBackupManager;
 
+use Richardhj\ContaoBackupManager\DependencyInjection\CompilerPass\ProvideFilesystemsPass;
+use Richardhj\ContaoBackupManager\DependencyInjection\ContaoBackupManagerExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class RichardhjContaoBackupManagerBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
 
+        $container->addCompilerPass(new ProvideFilesystemsPass());
+    }
+
+    public function getContainerExtension()
+    {
+        if (null === $this->extension) {
+            $this->extension = new ContaoBackupManagerExtension();
+        }
+
+        return $this->extension;
+    }
 }


### PR DESCRIPTION
This adds an encryption decoration layer to enable encrypted backups on remote storages.

Example configuration:
```yml

contao_backup_manager:
  storage:

    hetzner_enc:
      type: Encrypted
      storage: hetzner
      encryption_key: 'aaaabbbbbcccc'

    hetzner:
      type: Sftp
      host: example.com
      username: 'test'
      password: 'test'
      port: 22
      root: '/db'
      timeout: 10
```